### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastrlock" %}
-{% set version = "0.6" %}
+{% set version = "0.8.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,27 +7,32 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9f5d6ec9fe130b7490bb04572134392420b72bd0842185e02d461a797d6bc749
+  sha256: 4af6734d92eaa3ab4373e6c9a1dd0d5ad1304e172b1521733c6c3b3d73c8fa5d
 
 build:
-  number: 1
+  number: 0
   # We need to pass --with-cython to force cython to regenerate the .c file
-  script: {{ PYTHON }} -m pip install . --global-option="--with-cython" -vv
+  script: {{ PYTHON }} -m pip install . --global-option="--with-cython" --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   build:
-    - {{ compiler("c") }}
-    - {{ compiler("cxx") }}
+    - {{ compiler('c') }}
   host:
     - python
     - pip
+    - setuptools
     - cython
+    - wheel
   run:
     - python
 
 test:
   imports:
     - fastrlock
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/scoder/fastrlock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9f5d6ec9fe130b7490bb04572134392420b72bd0842185e02d461a797d6bc749
 
 build:
-  number: 0
+  number: 1
   # We need to pass --with-cython to force cython to regenerate the .c file
   script: {{ PYTHON }} -m pip install . --global-option="--with-cython" -vv
 


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

Update to 0.8.3
https://github.com/scoder/fastrlock/tree/v0.8.3